### PR TITLE
Regex for settings should be non-greedy

### DIFF
--- a/skinnydip.py
+++ b/skinnydip.py
@@ -97,7 +97,7 @@ WAIT_FOR_TEMP_REGEX = r"(?P<wait_for_temp>^G1 E-\d\d.*\n)(^G1 E-.*$\n)" + \
 TOOLCHANGE_TEMP_REGEX = r"M220 B.*\nM220 S(?P<speed_override>\d.*)\n" + \
                         r"(M.*\n)?(?P<temp_start>; CP TOOLCHANGE UNLOAD)"
 SETTINGS_REGEX = r"(?P<previous_tool>^T[01234].*$)(?P<otherstuff>(.*\n)" + \
-                 r"{10,250}); SKINNYDIP CONFIGURATION START.*\n" + \
+                 r"{10,250}?); SKINNYDIP CONFIGURATION START.*\n" + \
                  r"(?P<parameters>(; .*\n){1,11});.?SKINNYDIP " + \
                  r"CONFIGURATION END"
 COOLING_MOVE_REGEX = r"(?P<dip_pos>G1 E-).*\n(.*\n){1,5}(?P<new_tool>T\d)"


### PR DESCRIPTION
Regex for settings should be non-greedy so that it doesn't catch next tool's settings on really small layers with only a few moves and small wipe towers.

Maybe also other similar regex parts should be non-greedy, I didn't touch them because I did not have time to dig deeper into the script.

BTW thanks a lot for this script! It looks like that it made my MMU2S reliable and that's something. Currently fighting blobs on the wipe tower that sometimes lead to a crash and a layer shift, but I hope that I will just tune the insertion length and they will be gone. Other than that printing PETG with PLA supports (with similar configuration to solubles) is working great!
